### PR TITLE
Fix bugs on both 768css and 1024css

### DIFF
--- a/assets/css/1024.css
+++ b/assets/css/1024.css
@@ -5,6 +5,9 @@
   /* No need to do anything with the header */
 
   /* Headlines styles */
+  .headlines {
+    grid-template: 38vh 38vh / 65% 35%;
+  }
 
   /* Latest news styles */
 
@@ -13,7 +16,23 @@
   .sections-u-row,
   .latest-deals {
     width: 85%;
-    margin: 0 auto;
+    margin: 10px auto 0 auto;
+  }
+
+  .latest-news,
+    {
+    margin-top: 50px;
+  }
+
+  .latest-funding-rounds {
+    margin-bottom: 50px;
+  }
+
+  .latest-news header a,
+  .latest-funding-rounds header a,
+  .sections-u-row header a,
+  .latest-deals header a {
+    font-size: 32px;
   }
 
   .latest-news-articles,
@@ -26,12 +45,25 @@
   }
 
   .latest-news-articles {
-    height: 235px;
+    height: 20vw;
   }
 
   .latest-news-articles:last-child,
   .deal:last-child {
     display: none;
+  }
+
+  .latest-news-articles-thumb {
+    height: 13vw;
+  }
+
+  .hf-d-articles {
+    height: 25vw;
+  }
+
+  .hf-d-latest-title a.hf-d-latest-title-link,
+  .latest-deals-header a.latest-deals-see-deals {
+    font-size: 16px;
   }
 
 }

--- a/assets/css/768.css
+++ b/assets/css/768.css
@@ -12,6 +12,7 @@
 }
 
 @media only screen and (min-width: 768px) {
+
   /* unhide main header nav */
   .bottom-nav {
     margin-left: 110px;
@@ -107,7 +108,7 @@
     justify-content: space-between;
     flex-wrap: wrap;
     width: 95%;
-    margin: 0 auto;
+    margin: 42px auto 0 auto;
   }
 
   .latest-news-header {
@@ -115,13 +116,13 @@
   }
 
   .latest-news-header a {
-    font-size: 28px;
+    font-size: 30px;
   }
 
   .latest-news-articles {
     flex-basis: 31.6%;
-    margin: 10px 0 30px 0;
-    height: 50vh;
+    margin-top: 10px;
+    height: 44vh;
   }
 
   .latest-news-articles a {
@@ -139,7 +140,7 @@
 
   .latest-news-articles-thumb {
     width: 100%;
-    height: 70%;
+    height: 19vw;
     margin-bottom: 10px;
   }
 
@@ -177,7 +178,7 @@
   }
 
   .latest-funding-rounds-header {
-    font-size: 28px;
+    font-size: 30px;
   }
 
   .fund-rounds-links {
@@ -209,6 +210,14 @@
   .hf-d-box {
     flex-basis: 46%;
     margin: 0 0 30px 0;
+  }
+
+  .hf-d-articles {
+    height: 35vw;
+  }
+
+  .hf-d-header a {
+    font-size: 30px;
   }
 
   /* Latest deals styles */

--- a/index.html
+++ b/index.html
@@ -367,7 +367,7 @@
         <!-- App Section -->
         <section class="hf-d-box">
             <header class="hf-d-header">
-                <a href="">App ></a>
+                <a href="">Apps ></a>
             </header>
             <article class="hf-d-articles">
                 <div class="hf-d-cover-trigger"></div>


### PR DESCRIPTION
Hi @dipto0321. Please see the fixes i did. 

1. Fix image and box sizes for hf-d and latest-news
2. Put margins on headings at 1024css
3. Adjust heights of article boxes and background image containers

In particular please check the transition from 768px to 1024px, and also from 1024px up.. I fixed all the sizing of the images and also the sizes of the boxes.. Both in the 768.css and the 1024.css